### PR TITLE
Add: comments for bug

### DIFF
--- a/src/Utils/PGP.cc
+++ b/src/Utils/PGP.cc
@@ -126,6 +126,9 @@ namespace PGP {
         close(datafd);
 
         string result = "";
+        // In this case, string(passphrase) not filtering anything
+        // It cause command injection
+        // And Logically, it is not possible to process special characters.(e.g. !, @)
         string command = "echo " + string(passphrase) + \
                          " | /usr/bin/gpg --armor --no-tty --passphrase-fd 0 " \
                          "--decrypt " + path + " 2>/dev/null";


### PR DESCRIPTION
They use popen() function and input param like this.
```
        string command = "echo " + string(passphrase) + \
                         " | /usr/bin/gpg --armor --no-tty --passphrase-fd 0 " \
                         "--decrypt " + path + " 2>/dev/null";
```
Command injection is possible because we can input the passphrase value.
You can bypass it by typing ";[cmd]; \ " on the passphrase.

And if you write code like above, special characters can not be used.
So anyone who has special character password can not log in.


![image](https://user-images.githubusercontent.com/26449129/38294416-be21dfbc-3825-11e8-9cca-f81d470a89df.png)
