### PR TITLE
Report the bug in TCP connection

### DIFF
--- a/src/Packet/Packet.cc
+++ b/src/Packet/Packet.cc
@@ -10,6 +10,7 @@
 #include "Packet.hh"
 #include "PacketBuilder.hh"
 
+// The assumption is that the input value is always correct for the protocol.
 namespace Packet {
     // XXX: PACKET INTERFACE
     Packet* Unserialize(ReadCTX *ctx) {


### PR DESCRIPTION
In `Packet.cc` there are lots of parse function.
The assumption is that the input value is always correct for the protocol in TCP connection.
So If you receive an abnormal value, the program dies.

![image](https://user-images.githubusercontent.com/26449129/38401940-b16ba928-3993-11e8-8e65-92db3ec76799.png)

Thank you.
